### PR TITLE
Add extra-show and allow custom number-gap

### DIFF
--- a/src/equate.typ
+++ b/src/equate.typ
@@ -524,6 +524,8 @@
 // - number-mode: Whether to number all lines or only lines containing a label.
 //                Must be either "line" or "label".
 // - debug: Whether to show alignment spacers for debugging.
+// - extra-show: Show rule which is applied to block equation that are layouted
+//               by equate.
 //
 // Returns: The body with the applied show rules.
 #let equate(
@@ -531,6 +533,7 @@
   sub-numbering: false,
   number-mode: "line",
   debug: false,
+  extra-show: it => it,
   body
 ) = {
   // Validate parameters.
@@ -644,6 +647,10 @@
         // Update state to allow correct referencing.
         sub-numbering-state.update(_ => sub-numbering)
 
+        // Apply extra-show rule to allow for customizing the container of
+        // equate's block equations.
+        show: extra-show
+
         layout-line(
           lines.first(),
           number: number,
@@ -671,6 +678,10 @@
 
     // Update state to allow correct referencing.
     sub-numbering-state.update(_ => sub-numbering)
+
+    // Apply extra-show rule to allow for customizing the container of equate's
+    // block equations.
+    show: extra-show
 
     // Layout equation as grid to allow page breaks.
     block(grid(

--- a/src/equate.typ
+++ b/src/equate.typ
@@ -183,6 +183,7 @@
 #let layout-line(
   number: none,
   number-align: none,
+  number-gap: .5em,
   number-width: auto,
   text-dir: auto,
   line
@@ -232,12 +233,11 @@
 
   let num = box(width: number-width, align(number-align, number))
   let line-width = measure(equation(line.join(), measure: true)).width
-  let gap = 0.5em
 
   layout(bounds => {
     let space = if bounds.width.pt().is-infinite() {
       // If we're in an unbounded container, the number is placed right next to
-      // the equation body, with only the `gap` as spacing.
+      // the equation body, with only the `number-gap` as spacing.
       0pt
     } else if equation-align == center {
       bounds.width - line-width - 2 * number-width
@@ -247,19 +247,19 @@
 
     let body = if number-align.x == left {
       if equation-align == center {
-        h(-gap) + num + h(space / 2 + gap) + line.join() + h(space / 2) + hide(num)
+        h(-number-gap) + num + h(space / 2 + number-gap) + line.join() + h(space / 2) + hide(num)
       } else if equation-align == right {
-        num + h(space + 2 * gap) + line.join()
+        num + h(space + 2 * number-gap) + line.join()
       } else {
-        h(-gap) + num + h(gap) + line.join() + h(space + gap)
+        h(-number-gap) + num + h(number-gap) + line.join() + h(space + number-gap)
       }
     } else {
       if equation-align == center {
-        hide(num) + h(space / 2) + line.join() + h(space / 2 + gap) + num + h(-gap)
+        hide(num) + h(space / 2) + line.join() + h(space / 2 + number-gap) + num + h(-number-gap)
       } else if equation-align == right {
-        h(space + gap) + line.join() + h(gap) + num + h(-gap)
+        h(space + number-gap) + line.join() + h(number-gap) + num + h(-number-gap)
       } else {
-        line.join() + h(space + 2 * gap) + num
+        line.join() + h(space + 2 * number-gap) + num
       }
     }
 
@@ -296,8 +296,7 @@
     .enumerate()
     .filter(((i, line)) => {
       if i not in labelled { return false }
-      return line.last().text == "<equate:revoke>"
-    })
+      return line.last().text == "<equate:revoke>" })
     .map(((i, _)) => i)
 
   // The "revoke" label shall not count as a labelled line.
@@ -531,6 +530,7 @@
 #let equate(
   breakable: auto,
   sub-numbering: false,
+  number-gap: .5em,
   number-mode: "line",
   debug: false,
   extra-show: it => it,
@@ -652,6 +652,7 @@
         extra-show(layout-line(
           lines.first(),
           number: number,
+          number-gap: number-gap,
           number-align: number-align,
           text-dir: text-dir
         ))
@@ -698,6 +699,7 @@
           line,
           number: number,
           number-align: number-align,
+          number-gap: number-gap,
           number-width: max-number-width,
           text-dir: text-dir
         )

--- a/src/equate.typ
+++ b/src/equate.typ
@@ -647,16 +647,14 @@
         // Update state to allow correct referencing.
         sub-numbering-state.update(_ => sub-numbering)
 
-        // Apply extra-show rule to allow for customizing the container of
+        // Apply extra-show to allow for customizing the container of
         // equate's block equations.
-        show: extra-show
-
-        layout-line(
+        extra-show(layout-line(
           lines.first(),
           number: number,
           number-align: number-align,
           text-dir: text-dir
-        )
+        ))
 
         // Step back counter as we introducted an additional equation
         // that increased the counter by one.
@@ -679,12 +677,8 @@
     // Update state to allow correct referencing.
     sub-numbering-state.update(_ => sub-numbering)
 
-    // Apply extra-show rule to allow for customizing the container of equate's
-    // block equations.
-    show: extra-show
-
     // Layout equation as grid to allow page breaks.
-    block(grid(
+    extra-show(block(grid(
       columns: 1,
       row-gutter: par.leading,
       ..realign(lines).enumerate().map(((i, line)) => {
@@ -708,7 +702,7 @@
           text-dir: text-dir
         )
       })
-    ))
+    )))
 
     // Revert equation counter step(s).
     if it.numbering == none {


### PR DESCRIPTION
Thank you for this package!

This PR contains two changes. First, it adds the `extra-show` parameter to the `equate` function which allows users to inject custom show rules or containers around each block equation handled by equate. Second, it adds the `number-gap` parameter of the `equate` function to allow users to customize the distance between the equation and the number. Both changes are backward compatible.

### Why add `extra-show`?
In my case, I wanted to set up my documents so that they can be exported both as PDF and as HTML. In plain Typst (without the equate package), you can use the following show rule to embed equations as SVG images:
```typst
#import "@preview/bullseye:0.1.0"

#show math.equation.where(block: true): bullseye.show-target(
  html: it => html.frame(it),
  paged: it => it,
)
```

However, the above does not work when using equate, because equate breaks up the `math.equation` to create its layout. If you apply a show rule on inline equations, they show up, but their alignment is broken because equate's layout (spacing etc.) gets ignored during HTML export. So, I wanted to add some show rule that applies to the entire block equation even when using equate. With this PR, we can add this in the call to `equate` like so:
```typst
#import "@preview/bullseye:0.1.0"
#import "@preview/equate:0.3.2": equate

#show: equate.with(extra-show: it => bullseye.show-target(
  html: it => html.frame(it),
  paged: it => it,
))
```

I also considered adding HTML support directly to equate, but I think this is better because it is more flexible and allows even further customization. Also this means that the equate won't depend on any experimental HTML features of Typst.